### PR TITLE
Support values in decl.Var

### DIFF
--- a/changelog/@unreleased/pr-58.v2.yml
+++ b/changelog/@unreleased/pr-58.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support values in decl.Var
+  links:
+  - https://github.com/palantir/goastwriter/pull/58

--- a/decl/var.go
+++ b/decl/var.go
@@ -8,12 +8,14 @@ import (
 	"go/ast"
 	"go/token"
 
+	"github.com/palantir/goastwriter/astgen"
 	"github.com/palantir/goastwriter/expression"
 )
 
 type Var struct {
-	Name string
-	Type expression.Type
+	Name  string
+	Type  expression.Type
+	Value astgen.ASTExpr
 }
 
 func NewVar(name string, typ expression.Type) *Var {
@@ -24,17 +26,17 @@ func NewVar(name string, typ expression.Type) *Var {
 }
 
 func (v *Var) ASTDecl() ast.Decl {
+	valueSpec := &ast.ValueSpec{
+		Names: []*ast.Ident{ast.NewIdent(v.Name)},
+	}
+	if v.Type != "" {
+		valueSpec.Type = v.Type.ToIdent()
+	}
+	if v.Value != nil {
+		valueSpec.Values = []ast.Expr{v.Value.ASTExpr()}
+	}
 	return &ast.GenDecl{
-		Tok: token.VAR,
-		Specs: []ast.Spec{
-			&ast.ValueSpec{
-				Names: []*ast.Ident{
-					ast.NewIdent(v.Name),
-				},
-				Type: &ast.Ident{
-					Name: string(v.Type),
-				},
-			},
-		},
+		Tok:   token.VAR,
+		Specs: []ast.Spec{valueSpec},
 	}
 }

--- a/decl/var_test.go
+++ b/decl/var_test.go
@@ -21,5 +21,22 @@ func TestVars(t *testing.T) {
 			},
 			want: `var sortedKeys []string`,
 		},
+		{
+			name: "var declaration with value",
+			val: &decl.Var{
+				Name:  "key",
+				Type:  "string",
+				Value: expression.StringVal("value"),
+			},
+			want: `var key string = "value"`,
+		},
+		{
+			name: "var declaration with value implied type",
+			val: &decl.Var{
+				Name:  "key",
+				Value: expression.StringVal("value"),
+			},
+			want: `var key = "value"`,
+		},
 	})
 }


### PR DESCRIPTION
## Before this PR
There was no way to make a variable declaration with a value

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support values in decl.Var
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/goastwriter/58)
<!-- Reviewable:end -->
